### PR TITLE
Added ownprops to bindActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.14.0
+
+- Added ownprops as optional argument to the actions creator
+
 ### 4.13.6
 
 - Better typing support

--- a/README.md
+++ b/README.md
@@ -212,6 +212,41 @@ const App = () => (
 );
 ```
 
+### Access props in actions
+
+The initial component props are passed to the actions creator.
+
+```js
+import compose from "lodash/fp/compose";
+import { withRouter } from "next/router";
+
+const Component = ({ goBack }) => <h1 onClick={() => goBack()}>Back</h1>;
+
+const actions = (store, ownProps) => {
+  // Ownprops is an optional second parameter to the actions creator
+  const { router } = ownProps;
+  return {
+    goBack: state => router.push(state.previousUrl)
+  };
+};
+
+const enhanced = compose(
+  withRouter,
+  connect(
+    mapToProps,
+    actions
+  )
+);
+
+const EnhancedComponent = enhance(Component);
+
+const App = () => (
+  <Provider store={store}>
+    <EnhancedComponent />
+  </Provider>
+);
+```
+
 ### Combining actions
 
 There's an utility function to combine actions on Redux Zero:

--- a/README.md
+++ b/README.md
@@ -217,32 +217,24 @@ const App = () => (
 The initial component props are passed to the actions creator.
 
 ```js
-import compose from "lodash/fp/compose";
-import { withRouter } from "next/router";
-
-const Component = ({ goBack }) => <h1 onClick={() => goBack()}>Back</h1>;
-
-const actions = (store, ownProps) => {
-  // Ownprops is an optional second parameter to the actions creator
-  const { router } = ownProps;
-  return {
-    goBack: state => router.push(state.previousUrl)
-  };
-};
-
-const enhanced = compose(
-  withRouter,
-  connect(
-    mapToProps,
-    actions
-  )
+const Component = ({ count, increment }) => (
+  <h1 onClick={() => increment()}>{count}</h1>
 );
 
-const EnhancedComponent = enhance(Component);
+const mapToProps = ({ count }) => ({ count });
+
+const actions = (store, ownProps) => ({
+  increment: state => ({ count: state.count + ownProps.value })
+});
+
+const ConnectedComponent = connect(
+  mapToProps,
+  actions
+)(Component);
 
 const App = () => (
   <Provider store={store}>
-    <EnhancedComponent />
+    <ConnectedComponent value={10} />
   </Provider>
 );
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.13.6",
+  "version": "4.14.0",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",
@@ -10,8 +10,10 @@
     "lint": "tslint src/**/*.ts src/**/*.tsx",
     "test": "jest",
     "test:watch": "jest --watch",
-    "format": "prettier --write rollup.config.js \"config/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\"",
-    "check": "npm run compile && npm run format && npm run lint && npm run test",
+    "format":
+      "prettier --write rollup.config.js \"config/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\"",
+    "check":
+      "npm run compile && npm run format && npm run lint && npm run test",
     "clean": "rimraf dist coverage",
     "prebuild": "npm run check && npm run clean",
     "build:umd": "cross-env NODE_ENV=umd rollup --config",
@@ -40,20 +42,12 @@
     "url": "https://github.com/concretesolutions/redux-zero"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/testSetup.js"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "setupFiles": ["<rootDir>/config/testSetup.js"],
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/config/preprocessor.js"
     },
-    "testMatch": [
-      "<rootDir>/src/**/*.spec.(ts|tsx)"
-    ]
+    "testMatch": ["<rootDir>/src/**/*.spec.(ts|tsx)"]
   },
   "devDependencies": {
     "@types/jest": "21.1.10",

--- a/src/react/components/connect.spec.tsx
+++ b/src/react/components/connect.spec.tsx
@@ -291,7 +291,36 @@ describe("redux-zero - react bindings", () => {
 
       expect(wrapper.html()).toBe("<h1>2</h1>");
     });
+    it("should provide actions with ownprops", () => {
+      store.setState({ count: 0 });
 
+      const Comp = ({ count, increment }) => (
+        <h1 onClick={increment}>{count}</h1>
+      );
+
+      const mapToProps = ({ count }) => ({ count });
+
+      const actions = (store, ownProps) => ({
+        increment: state => ({ count: state.count + ownProps.add })
+      });
+
+      const ConnectedComp = connect(mapToProps, actions)(Comp);
+
+      const App = () => (
+        <Provider store={store}>
+          <ConnectedComp add={10} />
+        </Provider>
+      );
+
+      const wrapper = mount(<App />);
+
+      expect(wrapper.html()).toBe("<h1>0</h1>");
+
+      wrapper.children().simulate("click");
+      wrapper.children().simulate("click");
+
+      expect(wrapper.html()).toBe("<h1>20</h1>");
+    });
     it("should provide actions with parameters and subscribe to changes", () => {
       store.setState({ count: 0 });
 

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -25,7 +25,7 @@ export class Connect extends React.Component<any> {
   }
   getActions() {
     const { actions } = this.props;
-    return bindActions(actions, this.context.store);
+    return bindActions(actions, this.context.store, this.props);
   }
   update = () => {
     const mapped = this.getProps();

--- a/src/utils/bindActions.spec.ts
+++ b/src/utils/bindActions.spec.ts
@@ -1,7 +1,11 @@
 import createStore from "../";
 import bindActions from "./bindActions";
 
-const getActions = ({ setState }) => ({
+const ownProps = {
+  foo: "bar"
+};
+
+const getActions = ({ setState }, ownProps) => ({
   syncAction: ({ count }) => ({ count: count + 1 }),
   syncActionWithParam: ({ count }, amount) => ({ count: count + amount }),
   successAsyncAction() {
@@ -24,7 +28,8 @@ const getActions = ({ setState }) => ({
     return Promise.reject({ message: "I'M ERROR" })
       .then(payload => ({ payload, loading: false }))
       .catch(error => ({ error, loading: false }));
-  }
+  },
+  useOwnPropsInAction: () => ({ message: ownProps.foo })
 });
 
 describe("bindActions", () => {
@@ -33,7 +38,7 @@ describe("bindActions", () => {
     store = createStore({ count: 0 });
     listener = jest.fn();
     store.subscribe(listener);
-    actions = bindActions(getActions, store);
+    actions = bindActions(getActions, store, ownProps);
   });
 
   it("should perform sync actions", () => {
@@ -80,4 +85,10 @@ describe("bindActions", () => {
       expect(FAILING_STATE.error).toEqual({ message: "I'M ERROR" });
       expect(FAILING_STATE.loading).toBe(false);
     }));
+
+  it("should bind ownprops", () => {
+    actions.useOwnPropsInAction();
+
+    expect(store.getState().message).toBe("bar");
+  });
 });

--- a/src/utils/bindActions.ts
+++ b/src/utils/bindActions.ts
@@ -1,8 +1,12 @@
 import set from "./set";
 import Store from "../interfaces/Store";
 
-export default function bindActions(actions: Function, store: Store): any {
-  actions = typeof actions === "function" ? actions(store) : actions;
+export default function bindActions(
+  actions: Function,
+  store: Store,
+  ownProps?: object
+): any {
+  actions = typeof actions === "function" ? actions(store, ownProps) : actions;
 
   let bound = {};
   for (let name in actions) {


### PR DESCRIPTION
Brings it more inline with `mapDispatchToProps` of `redux`. 

It allows me to do: 

```
// Action.js
export default (store, { fetch, router }) => ({
  login: async (
    {
      settings: {
        auth: { login = "/api/v1/auth/login" },
      },
    },
    username,
    password
  ) => {
    store.setState({
      credentials: {
        loading: true,
      },
    });

    const response = await fetch(login, {
      method: "post",
      body: {
        username,
        password,
      },
    });
    return {
      credentials: response,
    };
  },
  logout: async ({
    settings: {
      auth: { logout = "/api/v1/auth/logout" },
    },
  }) => {
    await fetch(logout, {
      method: "get",
    });
    router.push("/login");
    return {
      credentials: null,
    };
  },
});

```


```
// Credentials.js
import compose from "lodash/fp/compose";
import { connect } from "redux-zero/react";
import { withRouter } from "next/router";
import actions from "./actions";

const Credentials = ({ render, ...props }) => render(props);

const enhance = compose(
  withRouter,
  connect(
    ({ credentials }) => credentials,
    actions
  )
);

export default enhance(Credentials);

```