### PR TITLE
add this.props to preact getActions in Connect component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.15.0
+
+- Added ownprops to preact actions
+
 ### 4.14.0
 
 - Added ownprops as optional argument to the actions creator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/preact/components/Connect.spec.tsx
+++ b/src/preact/components/Connect.spec.tsx
@@ -283,6 +283,35 @@ describe("redux-zero - preact bindings", () => {
       expect(context.find("h1").text()).toBe("2");
     });
 
+    it("should provide actions with ownprops", () => {
+      store.setState({ count: 0})
+
+      const mapToProps = ({ count }) => ({ count });
+
+      const actions = (store, ownProps) => ({
+        increment: state => ({ count: state.count + ownProps.add })
+      });
+
+      const Comp = ({ count, increment }) => (
+        <h1 onClick={increment}>{count}</h1>
+      );
+
+      const ConnectedComp = connect(mapToProps, actions)(Comp);
+
+      const App = () => (
+        <Provider store={store}>
+          <ConnectedComp add={10} />
+        </Provider>
+      );
+
+      context = deep(<App />, { depth: Infinity });
+      expect(context.find("h1").text()).toBe("0");
+      context.find("[onClick]").simulate("click");
+      context.find("[onClick]").simulate("click");
+      expect(context.find("h1").text()).toBe("20");
+     
+    });
+
     it("should peform async actions correctly", done => {
       store.setState({ count: 0 });
 

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -20,7 +20,7 @@ export class Connect extends Component<any, {}> {
   }
   getActions() {
     const { actions } = this.props;
-    return bindActions(actions, this.context.store);
+    return bindActions(actions, this.context.store, this.props);
   }
   update = () => {
     const mapped = this.getProps();


### PR DESCRIPTION
Probably not related to my PR but for some reasons npm run check displayed errors concerning react (and not preact folder)

example:

> src/react/components/connect.tsx:16:29 - error TS2339: Property 'context' does not exist on type 'Connect'.