### PR TITLE
enhance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+### 5.0.0
+
+**BREAKING CHANGES**  
+- Add generics to `bindActions()` , `connect()` , `createStore()` , `Provider` , `Store` .
+	- Default: any
+
+note:
+If using createStore() with partial initial state, it will inferred to incorrect type.
+
+```tsx
+import createStore from "redux-zero";
+
+interface ReduxState {
+  a: number;
+  b: number;
+}
+
+const store = createStore({a: 3}); // Store<{a: 3}>
+const store = createStore<ReduxState>({a: 3}); // Store<Partial<ReduxState>>
+const store = createStore<ReduxState>({a: 3, b: 3}); // Store<ReduxState>
+```
+
 ### 4.15.2
 
 - Improved `reset` function on the store, now it makes reset to `initialState`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.15.2",
+  "version": "5.0.0",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/devtools/devtoolsMiddleware.ts
+++ b/src/devtools/devtoolsMiddleware.ts
@@ -87,15 +87,15 @@ function replay(store: Store, message: Message): void {
   }, 0);
 }
 
-function update(message: Message) {
+function update<T extends Store>(this: T, message: Message) {
   if (message.type === "DISPATCH") {
     if (
       message.payload.type === "JUMP_TO_ACTION" ||
       message.payload.type === "JUMP_TO_STATE"
     ) {
-      (<Store>this).setState(JSON.parse(message.state));
+      this.setState(JSON.parse(message.state));
     } else if (message.payload.type === "TOGGLE_ACTION") {
-      replay(<Store>this, message);
+      replay(this, message);
     }
   }
 }

--- a/src/interfaces/Props.ts
+++ b/src/interfaces/Props.ts
@@ -1,6 +1,6 @@
 import Store from "./Store";
 
-export default interface Props {
-  store: Store;
+export default interface Props<S = any> {
+  store: Store<S>;
   children: JSX.Element[] | JSX.Element;
 };

--- a/src/interfaces/Store.ts
+++ b/src/interfaces/Store.ts
@@ -1,7 +1,7 @@
-export default interface Store {
+export default interface Store<S = any> {
   middleware(...args: any[]): void;
-  setState(f: Function | object): void;
+  setState(f: ((state: S) => Partial<S>) | Partial<S>): void;
   subscribe(f: Function): () => void;
-  getState(): object;
+  getState(): S;
   reset(): void;
 };

--- a/src/preact/components/Provider.tsx
+++ b/src/preact/components/Provider.tsx
@@ -3,7 +3,7 @@ import { Component } from "preact";
 import Props from "../../interfaces/Props";
 import Store from "../../interfaces/Store";
 
-export default class Provider extends Component<Props, {}> {
+export default class Provider<S = any> extends Component<Props<S>, {}> {
   getChildContext() {
     return { store: this.props.store };
   }

--- a/src/react/components/Provider.tsx
+++ b/src/react/components/Provider.tsx
@@ -4,7 +4,7 @@ import Props from "../../interfaces/Props";
 import propValidation from "../../utils/propsValidation";
 import Store from "../../interfaces/Store";
 
-export default class Provider extends React.Component<Props> {
+export default class Provider<S = any> extends React.Component<Props<S>> {
   static childContextTypes = {
     store: propValidation
   };

--- a/src/react/components/connect.spec.tsx
+++ b/src/react/components/connect.spec.tsx
@@ -219,7 +219,7 @@ describe("redux-zero - react bindings", () => {
 
     it("should accept ownProps as the second parameter to mapToProps", () => {
       const Comp = ({ message }) => <h1>{message}</h1>;
-      const ConnectedComp = connect((state, ownProps) => ({
+      const ConnectedComp = connect((state, ownProps: any) => ({
         message: ownProps.someProp
       }))(Comp);
 

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import shallowEqual from "../../utils/shallowEqual";
 import propValidation from "../../utils/propsValidation";
 import bindActions from "../../utils/bindActions";
-type mapToProps = (state: object, ownProps?: object) => object;
+type mapToProps<S> = (state: S, ownProps?: object) => object;
 
 export class Connect extends React.Component<any> {
   static contextTypes = {
@@ -43,7 +43,10 @@ export class Connect extends React.Component<any> {
   }
 }
 
-export default function connect(mapToProps?: mapToProps, actions = {}) {
+export default function connect<S = any>(
+  mapToProps?: mapToProps<S>,
+  actions = {}
+) {
   return (Child: any) =>
     class ConnectWrapper extends React.Component<any> {
       render() {

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,10 +1,19 @@
 import Store from "../interfaces/Store";
 
-export default function createStore(
-  initialState: object = {},
+function createStore<S extends object = any>(): Store<Partial<S>>;
+function createStore<S extends object = any>(
+  initialState?: S,
+  middleware?: any
+): Store<S>;
+function createStore<S extends object = any>(
+  initialState?: Partial<S>,
+  middleware?: any
+): Store<Partial<S>>;
+function createStore<S extends object = any>(
+  initialState: Partial<S> | S = {},
   middleware: any = null
-): Store {
-  let state = initialState || {};
+): Store<S> | Store<Partial<S>> {
+  let state: Partial<S> & object = initialState || {};
   const listeners: Function[] = [];
 
   function dispatchListeners() {
@@ -13,10 +22,10 @@ export default function createStore(
 
   return {
     middleware,
-    setState(update: Function | object) {
+    setState(update: ((state: Partial<S>) => Partial<S>) | Partial<S>) {
       state = {
-        ...state,
-        ...typeof update === "function" ? update(state) : update
+        ...(state as object),
+        ...typeof update === "function" ? update(state) : update as object
       };
 
       dispatchListeners();
@@ -36,3 +45,4 @@ export default function createStore(
     }
   };
 }
+export default createStore;

--- a/src/svelte/components/connect.ts
+++ b/src/svelte/components/connect.ts
@@ -1,9 +1,12 @@
 import getDiff from "../../utils/getDiff";
-import bindActions from "../../utils/bindActions";
+import bindActions, { Action } from "../../utils/bindActions";
 import Store from "../../interfaces/Store";
 type mapToProps = (state: object, ownProps?: object) => object;
 
-export function getActions(store: Store, actions: Function) {
+export function getActions<S>(
+  store: Store<S>,
+  actions: { [key: string]: Action<S> }
+) {
   return bindActions(actions, store);
 }
 

--- a/src/utils/set.tsx
+++ b/src/utils/set.tsx
@@ -1,6 +1,6 @@
 import Store from "../interfaces/Store";
 
-export default function set(store: Store, ret: any) {
+export default function set(store: Store, ret: any): Promise<void> | void {
   if (ret != null) {
     if (ret.then) return ret.then(store.setState);
     store.setState(ret);


### PR DESCRIPTION
**THIS INCLUDES BREAKING CHANGES**  
if using createStore() with partial initial state, it will inferred to incorrect type,  
  
usage examples:

```ts
interface ReduxState { count: 3 }
```

```ts
// Store<ReduxState>
const store = createStore<ReduxState>({
  count: 3,
});
// Store<Partial<ReduxState>>
const store = createStore<ReduxState>();
```

```ts
const store = createStore<ReduxState>();
const boundActions = bindActions(
  {
    updateCount: ({ count }: Partial<ReduxState>, val: number) => ({
      count: count + val,
    }),
  },
  store
);
// boundActions = { updateCount: (...args: any[]) => void | Promise<void> };
```