### PR TITLE
Fix preact Provider for Preact X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.0.2
+- Fixed Provider and connect in preact biddings so they now work for Preact X
+
 ### 5.0.1
 
 - Added Redux-Devtools options params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -29,7 +29,8 @@ export class Connect extends Component<any, {}> {
     }
   };
   render({ children }, state, { store }) {
-    return children[0]({ store, ...state, ...this.actions });
+    const child = (children && children[0]) || children;
+    return child({ store, ...state, ...this.actions });
   }
 }
 

--- a/src/preact/components/Provider.tsx
+++ b/src/preact/components/Provider.tsx
@@ -8,6 +8,9 @@ export default class Provider<S = any> extends Component<Props<S>, {}> {
     return { store: this.props.store };
   }
   render() {
-    return this.props.children[0];
+    return (
+      (this.props.children && this.props.children[0]) ||
+      (this.props.children as JSX.Element)
+    );
   }
 }


### PR DESCRIPTION
The [Preact X alpha](https://github.com/developit/preact/releases/tag/10.0.0-alpha.0) made one breaking change that broke the Provider component and respective connect HoC:

> As a user the most noticable change will be that props.children is not guaranteed to be an array anymore.

To fix this [I shamelessly took the same approach as unistore](https://github.com/developit/unistore/blob/c266d1fb93b7c585d1a9110f4da35af0991a624c/src/integrations/preact.js#L67) and, if the 0 index in the children prop is missing just return the entire children prop instead.