### PR TITLE
In preact, re-run the mapStateToProps when the component props change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 5.0.5
+
+- Fixed connect in preact bindings to call the `mapStateToProps` function when the component props change, 
+not just when the state store changes 
+
 ### 5.0.4
 
 - Changing from `npm` to `yarn`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/preact/components/Connect.spec.tsx
+++ b/src/preact/components/Connect.spec.tsx
@@ -1,3 +1,4 @@
+/** @jsx h */
 import { h } from "preact";
 import { deep } from "preact-render-spy";
 
@@ -227,6 +228,35 @@ describe("redux-zero - preact bindings", () => {
 
       context = deep(<App />, { depth: Infinity });
       expect(context.output()).toEqual(<h1>some value</h1>);
+    });
+
+    it("should provide the state and map again when component props change", () => {
+      store.setState({
+        messages: {
+          foo: "hello",
+          bar: "bye"
+        }
+      });
+
+      const Comp = ({ message }) => <h1>{message}</h1>;
+
+      const mapToProps = ({ messages }, { name }) => ({
+        message: messages[name]
+      });
+
+      const ConnectedComp = connect(mapToProps)(Comp);
+
+      const App = ({ name }) => (
+        <Provider store={store}>
+          <ConnectedComp name={name} />
+        </Provider>
+      );
+
+      context = deep(<App name="foo" />, { depth: Infinity });
+      expect(context.output()).toEqual(<h1>hello</h1>);
+
+      context.render(<App name="bar" />);
+      expect(context.output()).toEqual(<h1>bye</h1>);
     });
   });
 

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -5,25 +5,36 @@ import bindActions from "../../utils/bindActions";
 
 export class Connect extends Component<any, {}> {
   unsubscribe;
-  state = this.getProps();
-  actions = this.getActions();
+  actions;
+
+  constructor(props: any, context: any) {
+    super(props, context);
+    this.state = this.getProps(props, context);
+    this.actions = this.getActions();
+  }
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update);
   }
   componentWillUnmount() {
     this.unsubscribe(this.update);
   }
-  getProps() {
-    const { mapToProps } = this.props;
-    const state = (this.context.store && this.context.store.getState()) || {};
-    return mapToProps ? mapToProps(state, this.props) : state;
+  componentWillReceiveProps(nextProps: any, nextContext: any): void {
+    const mapped = this.getProps(nextProps, nextContext);
+    if (!shallowEqual(mapped, this.state)) {
+      this.setState(mapped);
+    }
+  }
+  getProps(props, context) {
+    const { mapToProps } = props;
+    const state = (context.store && context.store.getState()) || {};
+    return mapToProps ? mapToProps(state, props) : state;
   }
   getActions() {
     const { actions } = this.props;
     return bindActions(actions, this.context.store, this.props);
   }
   update = () => {
-    const mapped = this.getProps();
+    const mapped = this.getProps(this.props, this.context);
     if (!shallowEqual(mapped, this.state)) {
       this.setState(mapped);
     }

--- a/src/preact/components/Provider.spec.tsx
+++ b/src/preact/components/Provider.spec.tsx
@@ -1,3 +1,4 @@
+/** @jsx h */
 import { h, Component } from "preact";
 import { deep } from "preact-render-spy";
 


### PR DESCRIPTION
While developing I found myself having a weird behaviour where changes I was making to a component props would not be fully reflected in the tree. Turns out the connect HOC would only re-run the `mapStateToProps` function when state changes and not when the connected component props changed which meant that a function like this would not work correctly:

```js
function mapStateToProps({ entries = [] }, { filter }) {
  return {
    filtered: entries.filter(entry => entry.matches(filter))
  }
}
```

(in my case I was using the path parameters from [preact-router](https://github.com/developit/preact-router) to pick which entries to show).

I've modified the HOC to implement the `componentWillReceiveProps` lifecycle method and update the props from the state store there.