### PR TITLE
[React] `connect()`ed Components do not respond to new props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.1.2
+
+- Fix to make sure React's `connect()` components rerender when their props change.
+
 ### 5.1.1
 
 - Fixed missing types/Actions in the final bundle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -10,25 +10,36 @@ export class Connect extends React.Component<any> {
     store: propValidation
   };
   unsubscribe: any;
-  state = this.getProps();
-  actions = this.getActions();
+  actions: any;
+
+  constructor(props: any, context: any) {
+    super(props, context);
+    this.state = this.getProps(props, context);
+    this.actions = this.getActions();
+  }
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update);
   }
   componentWillUnmount() {
     this.unsubscribe(this.update);
   }
-  getProps() {
-    const { mapToProps } = this.props;
-    const state = (this.context.store && this.context.store.getState()) || {};
-    return mapToProps ? mapToProps(state, this.props) : state;
+  componentWillReceiveProps(nextProps: any, nextContext: any): void {
+    const mapped = this.getProps(nextProps, nextContext);
+    if (!shallowEqual(mapped, this.state)) {
+      this.setState(mapped);
+    }
+  }
+  getProps(props, context) {
+    const { mapToProps } = props;
+    const state = (context.store && context.store.getState()) || {};
+    return mapToProps ? mapToProps(state, props) : state;
   }
   getActions() {
     const { actions } = this.props;
     return bindActions(actions, this.context.store, this.props);
   }
   update = () => {
-    const mapped = this.getProps();
+    const mapped = this.getProps(this.props, this.context);
     if (!shallowEqual(mapped, this.state)) {
       this.setState(mapped);
     }


### PR DESCRIPTION
The component that results from calling `connect()()` caches the result of mapToProps in its state. This state gets updated when the store's state changes, but not when new props are passed. The component should either respond to new props, or call mapToProps on every render (as done here).