### PR TITLE
Added ComponentProps and updated connect method's type signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.1.3
+
+- Added ComponentProps concept and updated connect method type signature to accept generic type for ComponentProps so that type safety works when a connected component is used.
+
 ### 5.1.2
 
 - Fix to make sure React's `connect()` components rerender when their props change.

--- a/README.md
+++ b/README.md
@@ -390,19 +390,23 @@ const actions = (store, ownProps) => ({
   setLoading: (state, loading: boolean) => ({ loading })
 });
 
+interface ComponentProps {
+  value: string;
+}
+
 interface StoreProps {
   loading: boolean;
 }
 
-type Props = StoreProps & BoundActions<State, typeof actions>
+type Props = ComponentProps & StoreProps & BoundActions<State, typeof actions>
 
 class Component = (props: Props) => (
-  <h1 onClick={() => props.setLoading(!props.loading)}>Stuff</h1>
+  <h1 onClick={() => props.setLoading(!props.loading)}>{props.value}</h1>
 );
 
 const mapToProps = (state: State): StoreProps => ({ loading: state.loading });
 
-const ConnectedComponent = connect(
+const ConnectedComponent = connect<State, ComponentProps>(
   mapToProps,
   actions
 )(Component);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -54,12 +54,12 @@ export class Connect extends React.Component<any> {
   }
 }
 
-export default function connect<S = any, C = any>(
+export default function connect<S = any, P = any>(
   mapToProps?: mapToProps<S>,
   actions = {}
 ) {
   return (Child: any) =>
-    class ConnectWrapper extends React.Component<C> {
+    class ConnectWrapper extends React.Component<P> {
       render() {
         const { props } = this;
 

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -54,12 +54,12 @@ export class Connect extends React.Component<any> {
   }
 }
 
-export default function connect<S = any>(
+export default function connect<S = any, C = any>(
   mapToProps?: mapToProps<S>,
   actions = {}
 ) {
   return (Child: any) =>
-    class ConnectWrapper extends React.Component<any> {
+    class ConnectWrapper extends React.Component<C> {
       render() {
         const { props } = this;
 


### PR DESCRIPTION
Added ComponentProps and updated connect method's signature to accept ComponentProps so that types are preserved when a connected component is used.

Whit this change if `value` is not provided to `ConnectedComponent` then typescript will fail. Without this change no type checking happens on component props.