### PR TITLE
Better return type for bind actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.1.6
+
+* Update `bindActions` types to preserve argument types in TypeScript
+
 ### 5.1.5
 
 * Update Action type to support promise returning actions in TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/utils/bindActions.ts
+++ b/src/utils/bindActions.ts
@@ -2,11 +2,13 @@ import bindAction from "./bindAction";
 import Store from "../interfaces/Store";
 import { Action } from "../types";
 
+type OmitFirstArg<F, R> = F extends (x: any, ...args: infer P) => any ? (...args: P) => R : never;
+
 export default function bindActions<S, T extends { [key: string]: Action<S> }>(
   actions: ((store: Store<S>, ownProps) => T) | T,
   store: Store<S>,
   ownProps?: object
-): { [K in keyof T]: (...args: any[]) => Promise<void> | void } {
+): { [K in keyof T]: OmitFirstArg<T[K], Promise<void> | void> } {
   actions = typeof actions === "function" ? actions(store, ownProps) : actions;
 
   let bound: { [key: string]: (...args: any[]) => Promise<void> | void } = {};
@@ -16,5 +18,5 @@ export default function bindActions<S, T extends { [key: string]: Action<S> }>(
     bound[name] = bindAction(action, store);
   }
 
-  return bound as { [K in keyof T]: (...args: any[]) => Promise<void> | void };
+  return bound as { [K in keyof T]: OmitFirstArg<T[K], Promise<void> | void> };
 }


### PR DESCRIPTION
This changes the return type to preserve the function signatures so you don't just get `(...args: any[])` for all the actions.