### PR TITLE
Renaming UNSAFE_componentWillUnmount to componentWillUnmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.1.7
+
+* Renaming `UNSAFE_componentWillUnmount` to `componentWillUnmount`
+
 ### 5.1.6
 
 * Update `bindActions` types to preserve argument types in TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -20,7 +20,7 @@ export class Connect extends React.Component<any> {
   UNSAFE_componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update);
   }
-  UNSAFE_componentWillUnmount() {
+  componentWillUnmount() {
     this.unsubscribe(this.update);
   }
   UNSAFE_componentWillReceiveProps(nextProps: any, nextContext: any): void {


### PR DESCRIPTION
Hi.

After updating redux-zero on my projects to version >= 5.1.4, i got a new warning message:
<img width="639" alt="Screenshot 2020-05-29 at 20 46 26" src="https://user-images.githubusercontent.com/9103819/83279851-2ba96980-a1ef-11ea-8e23-aedea926469a.png">

After a little research, i found out that starting from version 5.1.4, the non-existent `UNSAFE_componentWillUnmount` method is used (i didn't find any mention of it in the official React [documentation](https://reactjs.org/docs/react-component.html#componentwillunmount)).